### PR TITLE
Add example tests for current hash printing

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -18,8 +18,9 @@ module Mocha
     end
 
     module HashMethods
-      def mocha_inspect(wrapped = true)
+      def mocha_inspect(placeholder = nil)
         unwrapped = collect { |key, value| "#{key.mocha_inspect} => #{value.mocha_inspect}" }.join(', ')
+        wrapped = !Hash.ruby2_keywords_hash?(self)
         wrapped ? "{#{unwrapped}}" : unwrapped
       end
     end

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -79,7 +79,7 @@ module Mocha
     def argument_description
       signature = arguments.mocha_inspect
       signature = signature.gsub(/^\[|\]$/, '')
-      signature = signature.gsub(/^\{|\}$/, '') if arguments.length == 1
+      # signature = signature.gsub(/^\{|\}$/, '') if arguments.length == 1
       "(#{signature})"
     end
   end

--- a/lib/mocha/parameters_matcher.rb
+++ b/lib/mocha/parameters_matcher.rb
@@ -23,7 +23,7 @@ module Mocha
     def mocha_inspect
       signature = matchers.mocha_inspect
       signature = signature.gsub(/^\[|\]$/, '')
-      signature = signature.gsub(/^\{|\}$/, '') if matchers.length == 1
+      # signature = signature.gsub(/^\{|\}$/, '') if matchers.length == 1
       "(#{signature})"
     end
 

--- a/test/acceptance/keyword_arguments_test.rb
+++ b/test/acceptance/keyword_arguments_test.rb
@@ -162,3 +162,68 @@ class KeywordArgumentsTest < Mocha::TestCase
     assert_passed(test_result)
   end
 end
+
+
+class PositionalAndKeywordHashInspectTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_single_hash_parameters_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with({ :foo => 42 })
+      mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+    ], test_result.failure_message_lines
+  end
+
+  def test_unexpected_keyword_arguments_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with(:foo => 42)
+      mock.method(:key => 42) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+    ], test_result.failure_message_lines
+  end
+
+  def test_last_hash_parameters_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with(1, { :foo => 42 })
+      mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+    ], test_result.failure_message_lines
+  end
+
+  def test_unexpected_keyword_arguments_with_other_positionals_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with(1, :foo => 42)
+      mock.method(1, :key => 42) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+    ], test_result.failure_message_lines
+  end
+end

--- a/test/acceptance/keyword_arguments_test.rb
+++ b/test/acceptance/keyword_arguments_test.rb
@@ -194,11 +194,19 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.expects(:method).with(:foo => 42)
       mock.method(:key => 42) # rubocop:disable Style/BracesAroundHashParameters
     end
-    assert_equal [
-      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
-      'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
-    ], test_result.failure_message_lines
+    if Mocha::RUBY_V27_PLUS
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+      ], test_result.failure_message_lines
+    else
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method({:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
+      ], test_result.failure_message_lines
+    end
   end
 
   def test_last_hash_parameters_in_invocation_and_expectation_print_correctly
@@ -220,11 +228,19 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.expects(:method).with(1, :foo => 42)
       mock.method(1, :key => 42) # rubocop:disable Style/BracesAroundHashParameters
     end
-    assert_equal [
-      'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
-      'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
-    ], test_result.failure_message_lines
+    if Mocha::RUBY_V27_PLUS
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+      ], test_result.failure_message_lines
+    else
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+      ], test_result.failure_message_lines
+    end
   end
 
   if Mocha::RUBY_V27_PLUS

--- a/test/acceptance/keyword_arguments_test.rb
+++ b/test/acceptance/keyword_arguments_test.rb
@@ -182,9 +182,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
     end
     assert_equal [
-      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+      'unexpected invocation: #<Mock:mock>.method({:key => 42})',
       'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+      '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
     ], test_result.failure_message_lines
   end
 
@@ -221,9 +221,71 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.method(1, :key => 42) # rubocop:disable Style/BracesAroundHashParameters
     end
     assert_equal [
-      'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+      'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
       'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+      '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
     ], test_result.failure_message_lines
+  end
+
+  if Mocha::RUBY_V27_PLUS
+    def test_single_hash_parameters_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with({ :foo => 42 })
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method({:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
+      ], test_result.failure_message_lines
+    end
+
+    def test_unexpected_keyword_arguments_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with(:foo => 42)
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(:key => 42) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+      ], test_result.failure_message_lines
+    end
+
+    def test_last_hash_parameters_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with(1, { :foo => 42 })
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+      ], test_result.failure_message_lines
+    end
+
+    def test_unexpected_keyword_arguments_with_other_positionals_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with(1, :foo => 42)
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(1, :key => 42) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+      ], test_result.failure_message_lines
+    end
   end
 end

--- a/test/unit/hash_inspect_test.rb
+++ b/test/unit/hash_inspect_test.rb
@@ -7,10 +7,10 @@ class HashInspectTest < Mocha::TestCase
     assert_equal '{:a => true}', hash.mocha_inspect
   end
 
-  def test_should_return_unwrapped_hash_when_wrapped_is_false
-    hash = { :a => true }
-    assert_equal ':a => true', hash.mocha_inspect(false)
-  end
+  # def test_should_return_unwrapped_hash_when_wrapped_is_false
+  #   hash = { :a => true }
+  #   assert_equal ':a => true', hash.mocha_inspect(false)
+  # end
 
   def test_should_use_mocha_inspect_on_each_item
     hash = { :a => 'mocha' }

--- a/test/unit/parameters_matcher_test.rb
+++ b/test/unit/parameters_matcher_test.rb
@@ -99,18 +99,18 @@ class ParametersMatcherTest < Mocha::TestCase
     assert_equal '(1, 2, 3)', parameters_matcher.mocha_inspect
   end
 
-  def test_should_remove_curly_braces_if_hash_is_only_argument
-    params = [{ :a => 1, :z => 2 }]
-    parameters_matcher = ParametersMatcher.new(params)
-    assert_nil parameters_matcher.mocha_inspect.index('{')
-    assert_nil parameters_matcher.mocha_inspect.index('}')
-  end
+  # def test_should_remove_curly_braces_if_hash_is_only_argument
+  #   params = [{ :a => 1, :z => 2 }]
+  #   parameters_matcher = ParametersMatcher.new(params)
+  #   assert_nil parameters_matcher.mocha_inspect.index('{')
+  #   assert_nil parameters_matcher.mocha_inspect.index('}')
+  # end
 
-  def test_should_not_remove_curly_braces_if_hash_is_not_the_only_argument
-    params = [1, { :a => 1 }]
-    parameters_matcher = ParametersMatcher.new(params)
-    assert_equal '(1, {:a => 1})', parameters_matcher.mocha_inspect
-  end
+  # def test_should_not_remove_curly_braces_if_hash_is_not_the_only_argument
+  #   params = [1, { :a => 1 }]
+  #   parameters_matcher = ParametersMatcher.new(params)
+  #   assert_equal '(1, {:a => 1})', parameters_matcher.mocha_inspect
+  # end
 
   def test_should_indicate_that_matcher_will_match_any_actual_parameters
     parameters_matcher = ParametersMatcher.new


### PR DESCRIPTION
@floehopper, hopefully you get a notification for this - I wanted to get your feedback on addressing https://github.com/freerange/mocha/pull/554#issuecomment-1261939795, and this seemed to be the easiest way to isolate the proposed changes.

Currently, when an unexpected invocation or unsatisfied expectation is made, the printed hashes somewhat disregard whether they're positional or keyword, which can be confusing. For example:
```ruby
# actual code
service = Service.new(a: params[:a], b: params[:b])

# test
Service.expects(:new).with(transformed_input).returns({ a: "123", b: "US" })

# unexpected invocation: Service.new(:a => "123", :b => "US")
# unsatisfied expectations:
# - expected exactly once, invoked never: Service.new(:a => "123", :b => "US")  # error message has "stripped" the hash and made it look like a keyword arg 
```

This PR is a spike to more accurately print Hashes. It works well in Ruby 2.7 and above, but below that all hashes are printed with the curly braces (see [example](https://github.com/wasabigeek/mocha/pull/2/files#diff-86fd3246d958412ec3fbced0d89d82692786ed33d717def754a8d20eedae8eacR204-R208)). I _think_ that's ok given that hashes and keyword args were treated mostly the same before 2.7, but what do you think?

To see the existing behaviour, you can reference this commit: https://github.com/wasabigeek/mocha/pull/2/commits/f957dab5431976a1a5716bda68df08a4f41fc67b.
